### PR TITLE
Add logs to check containers in /var/log/check

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,11 @@ def msg(msg, *args, **kwargs):
     if args or kwargs:
         msg = msg.format(*args, **kwargs)
     print(msg, file=sys.stderr)
+    try:
+        with open('/var/log/check', 'a') as f:
+            f.write("msg:" + msg + "\n")
+    except PermissionError:
+        pass
 
 
 def write_file(filepath, data):


### PR DESCRIPTION
Really really basic logging to file for the check container. This proved useful for when I had to debug the reason that my change to the resource's check function was not working properly. There is seemingly no other way to view logs in concourse.